### PR TITLE
tools: Fix typo in the IMAGE env var name

### DIFF
--- a/tools/packaging/build/build_payload.sh
+++ b/tools/packaging/build/build_payload.sh
@@ -10,7 +10,7 @@ else
 fi
 IMAGE=${IMAGE:-${DEFAULT_IMAGE}}
 
-docker rmi ${IMAGEE} -f
+docker rmi ${IMAGE} -f
 
 export SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export ENCLAVE_CC_ROOT="${SCRIPT_ROOT}/../../../"


### PR DESCRIPTION
IMAGEE was a typo, IMAGE should be the correct name.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>