### PR TITLE
github: Fix release tag format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Publish the Enclave CC release
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build-asset:


### PR DESCRIPTION
The release tag will be, according to the other repos under the Confidential Containers organisation, for instance, v0.2.0.

Prior to this patch we're considering it'd be 0.2.0, without the initial `v`.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>