### PR TITLE
enclave-agent: Bump image-rs to `v0.2.0`

### DIFF
--- a/src/enclave-agent/Cargo.toml
+++ b/src/enclave-agent/Cargo.toml
@@ -20,7 +20,7 @@ ctrlc = { version = "3.0", features = ["termination"] }
 tokio = { version = "1.14.0", features = ["full"] }
 async-trait = "0.1.42"
 
-image-rs = { git = "https://github.com/confidential-containers/image-rs", features = ["occlum_feature"], default-features = false }
+image-rs = { git = "https://github.com/confidential-containers/image-rs", tag = "v0.2.0", features = ["occlum_feature"], default-features = false }
 kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", rev = "4b57c04c3379d6adc7f440d156f0e4c42ac157df" }
 
 anyhow = "1.0.32"


### PR DESCRIPTION
As image-rs has tagged its `v0.2.0` release, let's make sure we're using it in what will become the `v0.2.0` release of Enclave CC.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>