### PR TITLE
ci: do not test with Go 1.16 anymore

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        go-version: [1.16.x, 1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.17.x, 1.18.x, 1.19.x]
 
     steps:
       - uses: actions/setup-go@v3
@@ -40,6 +40,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48.0
+          version: v1.50.1
           args: -v --timeout 5m
           working-directory: 'src/shim'


### PR DESCRIPTION
newer golang.org/x/sys depend on Go 1.17+ versions. Since 1.16 is no longer supported, we can just drop it in our CI to get golang.org/x/sys and other dependencies updated.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>