### PR TITLE
build: Remove $HOME/.rustup content from the final image

### DIFF
--- a/tools/packaging/build/agent-enclave-bundle/Dockerfile
+++ b/tools/packaging/build/agent-enclave-bundle/Dockerfile
@@ -80,7 +80,7 @@ WORKDIR /run/rune
 RUN tar xzf /run/enclave-agent/occlum_instance/occlum_instance.tar.gz && \
     rm -rf /run/enclave-agent
 
-RUN rm -r $HOME/.cargo
+RUN rm -rf $HOME/.cargo $HOME/.rustup
 RUN apt-get purge -y wget gnupg tzdata jq occlum occlum-toolchains-glibc make binutils libfuse2 libfuse3-3 ca-certificates rsync build-essential cmake git && apt-get autoremove -y
 RUN echo "/run/rune/occlum_instance/build/lib/" | tee /etc/ld.so.conf.d/occlum-pal.conf && \
     echo "/opt/sgxsdk/lib64" | tee /etc/ld.so.conf.d/sgxsdk.conf && \


### PR DESCRIPTION
We've noticed that in the fcbf7c924d280fe328aa96de09ab9ce72bf5ccb9 commit the image has grown from ~700MB to 1.6GB.  The commit introduced some changes that, for sure, should make the image bigger, but not *that big*.

After analysing the image content, I've noticed that the whole $HOME/.rustup has been added to the image, and that's most likely the root cause of the issue.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>