### PR TITLE
build: Remove /enclave-cc from the final image

### DIFF
--- a/tools/packaging/build/agent-enclave-bundle/Dockerfile
+++ b/tools/packaging/build/agent-enclave-bundle/Dockerfile
@@ -80,7 +80,7 @@ WORKDIR /run/rune
 RUN tar xzf /run/enclave-agent/occlum_instance/occlum_instance.tar.gz && \
     rm -rf /run/enclave-agent
 
-RUN rm -rf $HOME/.cargo $HOME/.rustup
+RUN rm -rf $HOME/.cargo $HOME/.rustup /enclave-cc
 RUN apt-get purge -y wget gnupg tzdata jq occlum occlum-toolchains-glibc make binutils libfuse2 libfuse3-3 ca-certificates rsync build-essential cmake git && apt-get autoremove -y
 RUN echo "/run/rune/occlum_instance/build/lib/" | tee /etc/ld.so.conf.d/occlum-pal.conf && \
     echo "/opt/sgxsdk/lib64" | tee /etc/ld.so.conf.d/sgxsdk.conf && \


### PR DESCRIPTION
This was also added by fcbf7c924d280fe328aa96de09ab9ce72bf5ccb9 and causes a /enclave-cc directory, with the enclave-cc source code, vendors, whatnot to be left as part of the agent-instance.tar.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>