### PR TITLE
Refactor enclave-agent

### DIFF
--- a/src/enclave-agent/Cargo.lock
+++ b/src/enclave-agent/Cargo.lock
@@ -1321,6 +1321,7 @@ dependencies = [
  "nix 0.23.2",
  "protobuf",
  "protocols",
+ "rstest",
  "serde",
  "serde_json",
  "simple-logging",
@@ -1590,6 +1591,12 @@ name = "futures-task"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -3584,6 +3591,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,6 +3713,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "sequoia-openpgp"

--- a/src/enclave-agent/Cargo.lock
+++ b/src/enclave-agent/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
- "env_logger",
+ "env_logger 0.9.3",
  "foreign-types 0.5.0",
  "futures",
  "futures-util",
@@ -289,7 +289,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -1314,6 +1314,7 @@ dependencies = [
  "bytes 0.4.12",
  "clap",
  "ctrlc",
+ "env_logger 0.10.0",
  "image-rs",
  "kata-sys-util",
  "libc",
@@ -1347,6 +1348,19 @@ checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -1777,6 +1791,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2082,18 @@ name = "ipnet"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "is_debug"
@@ -2584,7 +2619,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 

--- a/src/enclave-agent/Cargo.toml
+++ b/src/enclave-agent/Cargo.toml
@@ -6,30 +6,27 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-protobuf = { version = "=2.14.0" }
-bytes = "0.4.11"
-libc = "0.2.58"
-byteorder = "1.3.2"
-log = "0.4.11"
-simple-logging = "2.0.2"
-nix = "0.23.0"
-ttrpc = { git = "https://github.com/haosanzi/ttrpc-rust", features = ["async"] }
-ctrlc = { version = "3.0", features = ["termination"] }
-
-# Async runtime
-tokio = { version = "1.14.0", features = ["full"] }
+anyhow = "1.0.32"
 async-trait = "0.1.42"
-
+byteorder = "1.3.2"
+bytes = "0.4.11"
+clap = "2.33.3"
+ctrlc = { version = "3.0", features = ["termination"] }
 image-rs = { git = "https://github.com/confidential-containers/image-rs", features = ["occlum_feature", "cosign"], default-features = false, rev = "v0.3.0" }
 kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", rev = "4b57c04c3379d6adc7f440d156f0e4c42ac157df" }
-
-anyhow = "1.0.32"
-clap = "2.33.3"
-
+libc = "0.2.58"
+log = "0.4.11"
+nix = "0.23.0"
+protobuf = { version = "=2.14.0" }
 protocols = { path = "../libs/protocols" }
-
 serde = ">=1.0.9"
 serde_json = ">=1.0.9"
+simple-logging = "2.0.2"
+
+# Async runtime
+tokio = { version = "1.14.0", features = ["rt-multi-thread", "macros"] }
+
+ttrpc = { git = "https://github.com/haosanzi/ttrpc-rust", features = ["async"] }
 
 [build-dependencies]
 ttrpc-codegen = "0.2.0"

--- a/src/enclave-agent/Cargo.toml
+++ b/src/enclave-agent/Cargo.toml
@@ -33,3 +33,6 @@ serde_json = ">=1.0.9"
 
 [build-dependencies]
 ttrpc-codegen = "0.2.0"
+
+[dev-dependencies]
+rstest = "0.16.0"

--- a/src/enclave-agent/Cargo.toml
+++ b/src/enclave-agent/Cargo.toml
@@ -12,6 +12,10 @@ byteorder = "1.3.2"
 bytes = "0.4.11"
 clap = "2.33.3"
 ctrlc = { version = "3.0", features = ["termination"] }
+
+# logger module
+env_logger = "0.10.0"
+
 image-rs = { git = "https://github.com/confidential-containers/image-rs", features = ["occlum_feature", "cosign"], default-features = false, rev = "v0.3.0" }
 kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", rev = "4b57c04c3379d6adc7f440d156f0e4c42ac157df" }
 libc = "0.2.58"

--- a/src/enclave-agent/src/config.rs
+++ b/src/enclave-agent/src/config.rs
@@ -46,64 +46,51 @@ impl OcicryptConfig {
 mod test {
     use super::*;
 
-    #[test]
-    fn test_load_decrypt_config() {
-        struct ConfigCase {
-            path: String,
-            load_fail: bool,
-            result_key_provider: Option<String>,
-            result_security_validate: Option<bool>,
-        }
-        let decrypt_opt = "provider:attestation-agent:eaa_kbc::127.0.0.1:1234";
-        let config_dir = "test_data/decrypt_config";
-        let config_cases: Vec<ConfigCase> = vec![
-            ConfigCase {
-                path: format!("{}/{}", config_dir, "decrypt_config_not_existing.conf"),
-                load_fail: true,
-                result_key_provider: Some(decrypt_opt.to_string()),
-                result_security_validate: Some(true),
-            },
-            ConfigCase {
-                path: format!("{}/{}", config_dir, "decrypt_config_format_invalid.conf"),
-                load_fail: true,
-                result_key_provider: Some(decrypt_opt.to_string()),
-                result_security_validate: Some(true),
-            },
-            ConfigCase {
-                path: format!("{}/{}", config_dir, "decrypt_config_normal.conf"),
-                load_fail: false,
-                result_key_provider: Some(decrypt_opt.to_string()),
-                result_security_validate: Some(true),
-            },
-            ConfigCase {
-                path: format!("{}/{}", config_dir, "decrypt_config_disable_validate.conf"),
-                load_fail: false,
-                result_key_provider: Some(decrypt_opt.to_string()),
-                result_security_validate: Some(false),
-            },
-            ConfigCase {
-                path: format!("{}/{}", config_dir, "decrypt_config_default_validate.conf"),
-                load_fail: false,
-                result_key_provider: Some(decrypt_opt.to_string()),
-                result_security_validate: Some(true),
-            },
-            ConfigCase {
-                path: format!("{}/{}", config_dir, "decrypt_config_empty.conf"),
-                load_fail: false,
-                result_key_provider: None,
-                result_security_validate: Some(true),
-            },
-        ];
+    const CONFIG_DIR: &str = "test_data/decrypt_config";
+    const DECRYPT_OPT: &str = "provider:attestation-agent:eaa_kbc::127.0.0.1:1234";
 
-        for case in config_cases {
-            let result = DecryptConfig::load_from_file(&case.path);
-            if case.load_fail {
-                assert!(result.is_err());
-            } else {
-                let c = result.unwrap();
-                assert_eq!(c.key_provider, case.result_key_provider);
-                assert_eq!(c.security_validate, case.result_security_validate);
-            }
+    #[rstest::rstest]
+    #[case(
+        "decrypt_config_not_existing.conf",
+        true,
+        Some(DECRYPT_OPT),
+        Some(true)
+    )]
+    #[case(
+        "decrypt_config_format_invalid.conf",
+        true,
+        Some(DECRYPT_OPT),
+        Some(true)
+    )]
+    #[case("decrypt_config_normal.conf", false, Some(DECRYPT_OPT), Some(false))]
+    #[case(
+        "decrypt_config_disable_validate.conf",
+        false,
+        Some(DECRYPT_OPT),
+        Some(false)
+    )]
+    #[case(
+        "decrypt_config_default_validate.conf",
+        false,
+        Some(DECRYPT_OPT),
+        Some(true)
+    )]
+    #[case("decrypt_config_empty.conf", false, None, Some(true))]
+    fn test_load_decrypt_config(
+        #[case] path: &str,
+        #[case] load_fail: bool,
+        #[case] result_key_provider: Option<&str>,
+        #[case] result_security_validate: Option<bool>,
+    ) {
+        let path = format!("{CONFIG_DIR}/{path}");
+
+        let result = DecryptConfig::load_from_file(&path);
+        if load_fail {
+            assert!(result.is_err());
+        } else {
+            let c = result.unwrap();
+            assert_eq!(c.key_provider.as_deref(), result_key_provider);
+            assert_eq!(c.security_validate, result_security_validate);
         }
     }
 

--- a/src/enclave-agent/src/main.rs
+++ b/src/enclave-agent/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use clap::{crate_authors, crate_version, App, Arg};
+use log::info;
 use protocols::image_ttrpc;
 use tokio::signal::unix::{signal, SignalKind};
 use ttrpc::asynchronous::Server;
@@ -18,6 +19,8 @@ const TCP_SOCK_ADDR: &str = "tcp://0.0.0.0:7788";
 
 #[tokio::main(worker_threads = 1)]
 async fn main() -> Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
     let matches = App::new("Enclave agent")
         .version(crate_version!())
         .author(crate_authors!())
@@ -81,11 +84,11 @@ async fn main() -> Result<()> {
     let mut interrupt = signal(SignalKind::interrupt())?;
     server.start().await?;
 
-    println!("ttRPC server started: {:?}", sockaddr);
+    info!("ttRPC server started: {:?}", sockaddr);
 
     tokio::select! {
         _ = interrupt.recv() => {
-            println!("shutdown the server");
+            info!("shutdown the server");
             server.shutdown().await?;
         }
     };

--- a/src/enclave-agent/src/services/images.rs
+++ b/src/enclave-agent/src/services/images.rs
@@ -97,50 +97,23 @@ impl protocols::image_ttrpc::Image for ImageService {
 mod test {
     use super::*;
 
-    #[test]
-    fn test_get_container_id() {
-        struct ParseCase {
-            req: image::PullImageRequest,
-            is_ok: bool,
-        }
-        let cases: Vec<ParseCase> = vec![
-            ParseCase {
-                req: image::PullImageRequest {
-                    container_id: "redis".to_string(),
-                    ..Default::default()
-                },
-                is_ok: true,
-            },
-            ParseCase {
-                req: image::PullImageRequest {
-                    container_id: "redis_1.3".to_string(),
-                    ..Default::default()
-                },
-                is_ok: true,
-            },
-            ParseCase {
-                req: image::PullImageRequest {
-                    container_id: "redis:1.3".to_string(),
-                    ..Default::default()
-                },
-                is_ok: false,
-            },
-            ParseCase {
-                req: image::PullImageRequest {
-                    container_id: "".to_string(),
-                    ..Default::default()
-                },
-                is_ok: false,
-            },
-        ];
+    #[rstest::rstest]
+    #[case("redis", true)]
+    #[case("redis_1.3", true)]
+    #[case("redis:1.3", false)]
+    #[case("", false)]
+    fn test_get_container_id(#[case] container_id: &str, #[case] is_ok: bool) {
+        let req = image::PullImageRequest {
+            container_id: container_id.to_string(),
+            ..Default::default()
+        };
 
         let dc = DecryptConfig::load_from_file(
             &"test_data/decrypt_config/decrypt_config_normal.conf".to_string(),
         )
         .unwrap();
         let is = ImageService::new(dc);
-        for c in cases {
-            assert_eq!(is.get_container_id(&c.req).is_ok(), c.is_ok);
-        }
+        let res = is.get_container_id(&req);
+        assert_eq!(res.is_ok(), is_ok, "err: {:?}", res);
     }
 }

--- a/src/enclave-agent/src/services/images.rs
+++ b/src/enclave-agent/src/services/images.rs
@@ -7,6 +7,7 @@ use image_rs::config::ImageConfig;
 use image_rs::image::ImageClient;
 use image_rs::snapshots;
 use kata_sys_util::validate;
+use log::info;
 use protocols::image;
 use tokio::sync::Mutex;
 use ttrpc::{self, error::get_rpc_status as ttrpc_error};
@@ -53,7 +54,7 @@ impl ImageService {
             Some(dc_string.as_str())
         };
 
-        println!("Pulling {:?}", image);
+        info!("Pulling {:?}", image);
         self.image_client
             .lock()
             .await
@@ -81,7 +82,7 @@ impl protocols::image_ttrpc::Image for ImageService {
     ) -> ttrpc::Result<image::PullImageResponse> {
         match self.pull_image(&req).await {
             Ok(r) => {
-                println!("Pull image {:?} successfully", r);
+                info!("Pull image {:?} successfully", r);
                 let mut resp = image::PullImageResponse::new();
                 resp.image_ref = r;
                 return Ok(resp);


### PR DESCRIPTION
This pr does some little refactoring, including:
- use rstest for test cases
- reorder the dependency definitions, and delete useless features
- use log and env_logger crate to log instead of println.