### PR TITLE
boot-instance: allow more images to run

### DIFF
--- a/src/runtime-boot/init/src/main.rs
+++ b/src/runtime-boot/init/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let rootfs_key = b"c7-32-b3-ed-44-df-ec-7b-25-2d-9a-32-38-8d-58-61";
     let rootfs_upper_layer = "/sefs/upper";
     let rootfs_lower_layer = "/sefs/lower";
-    let rootfs_entry = "/bin";
+    let rootfs_entry = "/";
 
     // Get the key of FS image if needed
     let key = {

--- a/tools/packaging/build/boot-instance-bundle/jq.filter
+++ b/tools/packaging/build/boot-instance-bundle/jq.filter
@@ -1,3 +1,4 @@
 .resource_limits.user_space_size = "600MB" |
 .resource_limits.kernel_space_stack_size= "2MB" |
+.env.default |= . + ["LD_LIBRARY_PATH=/opt/occlum/glibc/lib:/lib/x86_64-linux-gnu/:/usr/local/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/usr/local/lib"] |
 if $ENV.SGX_MODE == "SIM" then .metadata.debuggable = true else .metadata.debuggable = false end


### PR DESCRIPTION
Setting rootfs_entry to /bin allowed to run binaries from that directory only. / works too and allows binaries from any path to run.

At the same time, Occlum did not get all the dynamically linked libraries loaded due to missing lib search paths. Add trusted LD_LIBRARY_PATH setting for the most common paths.