### PR TITLE
ci: use setup-go cache properly

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -21,11 +21,12 @@ jobs:
         go-version: [1.19.x, 1.20.x]
 
     steps:
+      - uses: actions/checkout@v3
+
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-
-      - uses: actions/checkout@v3
+          cache-dependency-path: src/shim/go.sum
 
       - name: Run build
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,13 +31,15 @@ jobs:
       PAYLOAD_ARTIFACTS: ${{ github.workspace }}/coco
 
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: 1.19
-          check-latest: true
       - uses: actions/checkout@v3
         with:
           path: ${{ github.workspace }}/src/github.com/confidential-containers/enclave-cc
+
+      - uses: actions/setup-go@v4
+        with:
+          check-latest: true
+          go-version-file: ${{ github.workspace }}/src/github.com/confidential-containers/enclave-cc/src/shim/go.mod
+          cache-dependency-path: ${{ github.workspace }}/src/github.com/confidential-containers/enclave-cc/src/shim/go.sum
 
       - name: Install confidential-containers/containerd
         if: ${{ matrix.runner == 'ubuntu-22.04' }}


### PR DESCRIPTION
Github Actions report the following:

shim basic test (ubuntu-22.04, 1.20.x)

Restore cache failed: Dependencies file is not found in
/home/runner/work/enclave-cc/enclave-cc. Supported file pattern: go.sum

Point setup-go to src/shim/go.sum to use cache.