### PR TITLE
dependabot: ignore containerd/ttrpc v1.2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "github.com/containerd/containerd"
+      - dependency-name: "github.com/containerd/ttrpc"
+        update-types: ["version-update:semver-minor"]
 
   # Check updates to action versions in .github/workflows
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
It requires more work to get this working so keep using v1.1.x.