### PR TITLE
deps: Bump image-rs to v0.5.1

### DIFF
--- a/src/enclave-agent/Cargo.lock
+++ b/src/enclave-agent/Cargo.lock
@@ -206,7 +206,7 @@ checksum = "2ce4f10ea3abcd6617873bae9f91d1c5332b4a778bd9ce34d0cd517474c1de82"
 [[package]]
 name = "attestation_agent"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/attestation-agent.git?rev=c939d21#c939d211fe5ac497715008e36161aff20cabb6e6"
+source = "git+https://github.com/confidential-containers/attestation-agent.git?tag=v0.5.0#c939d211fe5ac497715008e36161aff20cabb6e6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/image-rs?rev=b28eaae#b28eaae46bcea69ac28d079381b7aa1ef6851ad9"
+source = "git+https://github.com/confidential-containers/image-rs?tag=v0.5.1#767800855738c559d54b3f84810876b669ec3b83"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "ocicrypt-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/ocicrypt-rs?rev=55ab22d#55ab22d572ec385ba466085f3c78f4148dfd287e"
+source = "git+https://github.com/confidential-containers/ocicrypt-rs?tag=v0.5.1#3bf5bc4ebabe6d4695edf955b76dd3635c55d118"
 dependencies = [
  "aes 0.8.2",
  "anyhow",

--- a/src/enclave-agent/Cargo.toml
+++ b/src/enclave-agent/Cargo.toml
@@ -13,7 +13,7 @@ clap = "2.33.3"
 # logger module
 env_logger = "0.10.0"
 
-image-rs = { git = "https://github.com/confidential-containers/image-rs", default-features = false, rev = "b28eaae" }
+image-rs = { git = "https://github.com/confidential-containers/image-rs", default-features = false, tag = "v0.5.1" }
 kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", rev = "4b57c04c3379d6adc7f440d156f0e4c42ac157df" }
 log = "0.4.11"
 protocols = { path = "../libs/protocols" }


### PR DESCRIPTION
Let's update image-rs to the latest released tag.