### PR TITLE
Workflows: fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,9 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        asset:
-          - HW
-          - SIM
+        include:
+          - sgx_mode: SIM
+            kbc: sample-kbc
+          - sgx_mode: HW
+            kbc: cc-kbc
     steps:
       - name: Login to quay.io
         uses: docker/login-action@v2
@@ -23,10 +25,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # This is needed in order to keep the commit ids history
-      - name: Build Enclave CC Payload using SGX_MODE=${{ matrix.asset }}
+      - name: Build Enclave CC Payload using SGX_MODE=${{ matrix.sgx_mode }} KBC=${{ matrix.kbc }}
         run: |
           ./tools/packaging/build/build_payload.sh 
         env:
-          SGX_MODE: ${{ matrix.asset }}
+          SGX_MODE: ${{ matrix.sgx_mode }}
+          KBC: ${{ matrix.kbc }}
           CI: no
           PUSH: yes


### PR DESCRIPTION
Should the release workflow match the push workflow? Currently we are releasing a `SIM-cc-kbc` bundle, which does not match our CI bundles. Is this necessary? 

@Xynnn007 @mythi @dcmiddle 