### PR TITLE
workflows: fix payload push trigger syntax

### DIFF
--- a/.github/workflows/payload.yaml
+++ b/.github/workflows/payload.yaml
@@ -1,8 +1,8 @@
 name: Publish Enclave CC CI payloads for Confidential Containers
 on:
   push:
-    branch:
-      - main
+    branches:
+      - 'main'
 
 jobs:
   build-asset:


### PR DESCRIPTION
dependabot pushes to the repository trigger payload.yaml workflows which should not happen at all.

It's likely that Github does not like the branch names without hyphens and the filter gets broken.