### PR TITLE
ccruntime: Manage runtime class creation / deletion

### DIFF
--- a/tools/packaging/build/Dockerfile
+++ b/tools/packaging/build/Dockerfile
@@ -4,6 +4,7 @@ ARG ENCLAVE_CC_ARTIFACTS=./enclave-cc-static.tar.xz
 ARG DESTINATION=/opt/enclave-cc-artifacts
 
 COPY ${ENCLAVE_CC_ARTIFACTS} ${WORKDIR}
+COPY runtimeclass ${DESTINATION}/runtimeclass
 
 ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/tools/packaging/build/build_payload.sh
+++ b/tools/packaging/build/build_payload.sh
@@ -46,6 +46,7 @@ install -D ${SCRIPT_ROOT}/../deploy/enclave-cc-deploy.sh ${PAYLOAD_ARTIFACTS}/sc
 pushd $PAYLOAD_ARTIFACTS
 tar cfJ enclave-cc-static.tar.xz *
 cp ${SCRIPT_ROOT}/Dockerfile .
+cp -a ${SCRIPT_ROOT}/runtimeclass .
 docker build . -t ${IMAGE} -t ${DEFAULT_LATEST_IMAGE}
 if [ "${PUSH}" == "yes" ]; then
 	docker push ${IMAGE}

--- a/tools/packaging/build/runtimeclass/enclave-cc.yaml
+++ b/tools/packaging/build/runtimeclass/enclave-cc.yaml
@@ -1,0 +1,6 @@
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1
+metadata:
+    name: enclave-cc
+handler: enclave-cc

--- a/tools/packaging/deploy/enclave-cc-deploy.sh
+++ b/tools/packaging/deploy/enclave-cc-deploy.sh
@@ -25,6 +25,16 @@ function print_usage() {
 	echo "Usage: $0 [install/cleanup/reset]"
 }
 
+function create_runtimeclass() {
+	echo "Creating the runtime classes"
+	kubectl apply -f /runtimeclass/enclave-cc.yaml
+}
+
+function delete_runtimeclass() {
+	echo "Deleting the runtime classes"
+	kubectl delete -f /runtimeclass/enclave-cc.yaml
+}
+
 function get_container_runtime() {
 
 	local runtime=$(kubectl get node $NODE_NAME -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}')
@@ -167,10 +177,12 @@ function main() {
 	install)
 		install_artifacts
 		configure_cri_runtime "$runtime"
+		create_runtimeclass
 		kubectl label node "$NODE_NAME" --overwrite confidentialcontainers.org/enclave-cc=true
 		;;
 	cleanup)
 		cleanup_cri_runtime "$runtime"
+		delete_runtimeclass
 		kubectl label node "$NODE_NAME" --overwrite confidentialcontainers.org/enclave-cc=cleanup
 		remove_artifacts
 		;;


### PR DESCRIPTION
Kata Containers moved to managing the runtime class creation / deletion, leading to making the Operator "dumber", removing all the runtime class management from there.

Let's adapt to it on the Enclave CC side as well.