### PR TITLE
enclave-cc-deploy: Fix runtimeclass path

### DIFF
--- a/tools/packaging/deploy/enclave-cc-deploy.sh
+++ b/tools/packaging/deploy/enclave-cc-deploy.sh
@@ -27,12 +27,12 @@ function print_usage() {
 
 function create_runtimeclass() {
 	echo "Creating the runtime classes"
-	kubectl apply -f /runtimeclass/enclave-cc.yaml
+	kubectl apply -f /opt/enclave-cc-artifacts/runtimeclass/enclave-cc.yaml
 }
 
 function delete_runtimeclass() {
 	echo "Deleting the runtime classes"
-	kubectl delete -f /runtimeclass/enclave-cc.yaml
+	kubectl delete -f /opt/enclave-cc-artifacts/runtimeclass/enclave-cc.yaml
 }
 
 function get_container_runtime() {


### PR DESCRIPTION
Instead of using `/runtimeclass/enclave-cc.yaml`, let's use the full path for it `/opt/enclave-cc-artifacts/runtimeclass/enclave-cc.yaml`

This will fix the following error faced on the Operator CI side:
```
ubuntu@operator:~/operator$ kubectl -n confidential-containers-system logs cc-operator-daemon-install-j4fxn -c cc-runtime-install-pod
copying enclave-cc artifacts onto host
Add enclave-cc as a supported runtime for containerd
Configuration exists for plugins."io.containerd.grpc.v1.cri".containerd.runtimes.enclave-cc, overwriting
Creating the runtime classes
error: the path "/runtimeclass/enclave-cc.yaml" does not exist
```