### PR TITLE
deploy: Use host_systemctl

### DIFF
--- a/tools/packaging/deploy/ccruntime.yaml
+++ b/tools/packaging/deploy/ccruntime.yaml
@@ -23,10 +23,6 @@ spec:
         name: enclave-cc-conf
       - mountPath: /opt/confidential-containers/
         name: enclave-cc-artifacts
-      - mountPath: /var/run/dbus
-        name: dbus
-      - mountPath: /run/systemd
-        name: systemd
       - mountPath: /usr/local/bin/
         name: local-bin
     installerVolumes:
@@ -42,14 +38,6 @@ spec:
           path: /opt/confidential-containers/
           type: DirectoryOrCreate
         name: enclave-cc-artifacts
-      - hostPath:
-          path: /var/run/dbus
-          type: ""
-        name: dbus
-      - hostPath:
-          path: /run/systemd
-          type: ""
-        name: systemd
       - hostPath:
           path: /usr/local/bin/
           type: ""

--- a/tools/packaging/deploy/enclave-cc-deploy.sh
+++ b/tools/packaging/deploy/enclave-cc-deploy.sh
@@ -35,6 +35,10 @@ function delete_runtimeclass() {
 	kubectl delete -f /runtimeclass/enclave-cc.yaml
 }
 
+function host_systemctl() {
+	nsenter --target 1 --mount systemctl "${@}"
+}
+
 function get_container_runtime() {
 
 	local runtime=$(kubectl get node $NODE_NAME -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}')
@@ -42,11 +46,11 @@ function get_container_runtime() {
                 die "invalid node name"
 	fi
 	if echo "$runtime" | grep -qE 'containerd.*-k3s'; then
-		if systemctl is-active --quiet rke2-agent; then
+		if host_systemctl is-active --quiet rke2-agent; then
 			echo "rke2-agent"
-		elif systemctl is-active --quiet rke2-server; then
+		elif host_systemctl is-active --quiet rke2-server; then
 			echo "rke2-server"
-		elif systemctl is-active --quiet k3s-agent; then
+		elif host_systemctl is-active --quiet k3s-agent; then
 			echo "k3s-agent"
 		else
 			echo "k3s"
@@ -81,8 +85,8 @@ function configure_cri_runtime() {
 		configure_containerd
 		;;
 	esac
-	systemctl daemon-reload
-	systemctl restart "$1"
+	host_systemctl daemon-reload
+	host_systemctl restart "$1"
 }
 
 function configure_containerd() {
@@ -146,8 +150,8 @@ function cleanup_containerd() {
 
 function reset_runtime() {
 	kubectl label node "$NODE_NAME" confidentialcontainers.org/enclave-cc-
-	systemctl daemon-reload
-	systemctl restart "$1"
+	host_systemctl daemon-reload
+	host_systemctl restart "$1"
 }
 
 function main() {


### PR DESCRIPTION
The operator started using HostPID=true, allowing us to use nsenter to interact with systemd in the host. We do the same for kata payload installation with kata-deploy.

There's a little bit of chicken-egg problem here, as this PR depends on https://github.com/confidential-containers/operator/pull/242, and that PR depends on this one.