### PR TITLE
Update image-rs to v0.8.0 candidate

### DIFF
--- a/src/enclave-agent/Cargo.lock
+++ b/src/enclave-agent/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 [[package]]
 name = "attestation_agent"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=f4f89dab52652c31ebda65aae797462d3697d8c2#f4f89dab52652c31ebda65aae797462d3697d8c2"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=e5e6e69ae0ea01393a125cde8e2772ad98aba39c#e5e6e69ae0ea01393a125cde8e2772ad98aba39c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "attester"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=f4f89dab52652c31ebda65aae797462d3697d8c2#f4f89dab52652c31ebda65aae797462d3697d8c2"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=e5e6e69ae0ea01393a125cde8e2772ad98aba39c#e5e6e69ae0ea01393a125cde8e2772ad98aba39c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -757,7 +757,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=f4f89dab52652c31ebda65aae797462d3697d8c2#f4f89dab52652c31ebda65aae797462d3697d8c2"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=e5e6e69ae0ea01393a125cde8e2772ad98aba39c#e5e6e69ae0ea01393a125cde8e2772ad98aba39c"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=f4f89dab52652c31ebda65aae797462d3697d8c2#f4f89dab52652c31ebda65aae797462d3697d8c2"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=e5e6e69ae0ea01393a125cde8e2772ad98aba39c#e5e6e69ae0ea01393a125cde8e2772ad98aba39c"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2276,7 +2276,7 @@ dependencies = [
 [[package]]
 name = "kbc"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=f4f89dab52652c31ebda65aae797462d3697d8c2#f4f89dab52652c31ebda65aae797462d3697d8c2"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=e5e6e69ae0ea01393a125cde8e2772ad98aba39c#e5e6e69ae0ea01393a125cde8e2772ad98aba39c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2305,7 +2305,7 @@ dependencies = [
 [[package]]
 name = "kbs_protocol"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=f4f89dab52652c31ebda65aae797462d3697d8c2#f4f89dab52652c31ebda65aae797462d3697d8c2"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=e5e6e69ae0ea01393a125cde8e2772ad98aba39c#e5e6e69ae0ea01393a125cde8e2772ad98aba39c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2764,7 +2764,7 @@ dependencies = [
 [[package]]
 name = "ocicrypt-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=f4f89dab52652c31ebda65aae797462d3697d8c2#f4f89dab52652c31ebda65aae797462d3697d8c2"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=e5e6e69ae0ea01393a125cde8e2772ad98aba39c#e5e6e69ae0ea01393a125cde8e2772ad98aba39c"
 dependencies = [
  "aes",
  "anyhow",
@@ -3610,7 +3610,7 @@ dependencies = [
 [[package]]
 name = "resource_uri"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=f4f89dab52652c31ebda65aae797462d3697d8c2#f4f89dab52652c31ebda65aae797462d3697d8c2"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=e5e6e69ae0ea01393a125cde8e2772ad98aba39c#e5e6e69ae0ea01393a125cde8e2772ad98aba39c"
 dependencies = [
  "anyhow",
  "serde",

--- a/src/enclave-agent/Cargo.toml
+++ b/src/enclave-agent/Cargo.toml
@@ -13,7 +13,7 @@ clap = { version = "4.4.6", features = ["derive"] }
 # logger module
 env_logger = "0.10.0"
 
-image-rs = { git = "https://github.com/confidential-containers/guest-components.git", default-features = false, rev = "f4f89dab52652c31ebda65aae797462d3697d8c2" }
+image-rs = { git = "https://github.com/confidential-containers/guest-components.git", default-features = false, rev = "e5e6e69ae0ea01393a125cde8e2772ad98aba39c" }
 kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", rev = "4b57c04c3379d6adc7f440d156f0e4c42ac157df" }
 log = "0.4.20"
 protocols = { path = "../libs/protocols" }


### PR DESCRIPTION
Before cutting image-rs for v0.8.0, make sure the latest image-rs works for enclave-cc