### PR TITLE
bump: image-rs to new version

### DIFF
--- a/src/enclave-agent/Cargo.lock
+++ b/src/enclave-agent/Cargo.lock
@@ -174,28 +174,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "attestation_agent"
-version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5d4bb95578b611d15d6907b3419f5cb129572e51#5d4bb95578b611d15d6907b3419f5cb129572e51"
-dependencies = [
- "anyhow",
- "async-trait",
- "attester",
- "kbc",
- "kbs_protocol",
- "log",
- "resource_uri",
- "serde",
- "serde_json",
- "strum",
- "tokio",
- "toml 0.8.8",
-]
-
-[[package]]
 name = "attester"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5d4bb95578b611d15d6907b3419f5cb129572e51#5d4bb95578b611d15d6907b3419f5cb129572e51"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=ee6306cc96f40c7488f2e3d22b6de4b39b377ad5#ee6306cc96f40c7488f2e3d22b6de4b39b377ad5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -766,13 +747,14 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5d4bb95578b611d15d6907b3419f5cb129572e51#5d4bb95578b611d15d6907b3419f5cb129572e51"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=ee6306cc96f40c7488f2e3d22b6de4b39b377ad5#ee6306cc96f40c7488f2e3d22b6de4b39b377ad5"
 dependencies = [
  "aes-gcm",
  "anyhow",
  "base64 0.21.5",
  "ctr",
  "kbs-types",
+ "openssl",
  "rand 0.8.5",
  "rsa 0.9.6",
  "serde",
@@ -1387,28 +1369,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared 0.3.1",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.47",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1416,12 +1377,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1917,12 +1872,11 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5d4bb95578b611d15d6907b3419f5cb129572e51#5d4bb95578b611d15d6907b3419f5cb129572e51"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=ee6306cc96f40c7488f2e3d22b6de4b39b377ad5#ee6306cc96f40c7488f2e3d22b6de4b39b377ad5"
 dependencies = [
  "anyhow",
  "async-compression",
  "async-trait",
- "attestation_agent",
  "base64 0.21.5",
  "cfg-if",
  "dircpy",
@@ -1931,6 +1885,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
+ "kbc",
  "lazy_static",
  "libc",
  "log",
@@ -1939,6 +1894,7 @@ dependencies = [
  "oci-distribution",
  "oci-spec",
  "ocicrypt-rs",
+ "resource_uri",
  "sequoia-openpgp",
  "serde",
  "serde_json",
@@ -2173,19 +2129,18 @@ dependencies = [
  "slog",
  "slog-scope",
  "thiserror",
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
 name = "kbc"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5d4bb95578b611d15d6907b3419f5cb129572e51#5d4bb95578b611d15d6907b3419f5cb129572e51"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=ee6306cc96f40c7488f2e3d22b6de4b39b377ad5#ee6306cc96f40c7488f2e3d22b6de4b39b377ad5"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.5",
  "crypto",
- "foreign-types 0.5.0",
  "kbs_protocol",
  "log",
  "resource_uri",
@@ -2209,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "kbs_protocol"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5d4bb95578b611d15d6907b3419f5cb129572e51#5d4bb95578b611d15d6907b3419f5cb129572e51"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=ee6306cc96f40c7488f2e3d22b6de4b39b377ad5#ee6306cc96f40c7488f2e3d22b6de4b39b377ad5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2656,24 +2611,27 @@ dependencies = [
 [[package]]
 name = "ocicrypt-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5d4bb95578b611d15d6907b3419f5cb129572e51#5d4bb95578b611d15d6907b3419f5cb129572e51"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=ee6306cc96f40c7488f2e3d22b6de4b39b377ad5#ee6306cc96f40c7488f2e3d22b6de4b39b377ad5"
 dependencies = [
  "aes",
  "anyhow",
- "attestation_agent",
  "base64 0.21.5",
  "base64-serde",
  "cfg-if",
+ "crypto",
  "ctr",
  "hmac",
+ "kbc",
  "lazy_static",
  "openssl",
  "pin-project-lite",
+ "resource_uri",
  "ring 0.16.20",
  "serde",
  "serde_json",
  "sha2",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]
@@ -2707,7 +2665,7 @@ checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
- "foreign-types 0.3.2",
+ "foreign-types",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -3401,7 +3359,7 @@ dependencies = [
 [[package]]
 name = "resource_uri"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components.git?rev=5d4bb95578b611d15d6907b3419f5cb129572e51#5d4bb95578b611d15d6907b3419f5cb129572e51"
+source = "git+https://github.com/confidential-containers/guest-components.git?rev=ee6306cc96f40c7488f2e3d22b6de4b39b377ad5#ee6306cc96f40c7488f2e3d22b6de4b39b377ad5"
 dependencies = [
  "anyhow",
  "serde",
@@ -3821,15 +3779,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.47",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -4398,40 +4347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
-dependencies = [
- "indexmap 2.1.0",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -5093,15 +5008,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
-
-[[package]]
-name = "winnow"
-version = "0.5.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"

--- a/src/enclave-agent/Cargo.toml
+++ b/src/enclave-agent/Cargo.toml
@@ -13,7 +13,7 @@ clap = { version = "4.4.6", features = ["derive"] }
 # logger module
 env_logger = "0.10.0"
 
-image-rs = { git = "https://github.com/confidential-containers/guest-components.git", default-features = false, rev = "5d4bb95578b611d15d6907b3419f5cb129572e51" }
+image-rs = { git = "https://github.com/confidential-containers/guest-components.git", default-features = false, rev = "ee6306cc96f40c7488f2e3d22b6de4b39b377ad5" }
 kata-sys-util = { git = "https://github.com/kata-containers/kata-containers", rev = "4b57c04c3379d6adc7f440d156f0e4c42ac157df" }
 log = "0.4.20"
 protocols = { path = "../libs/protocols" }
@@ -33,14 +33,6 @@ default = ["cc-kbc-rustls-tls"]
 
 # confidential resource injection using sample-kbc
 simple = ["image-rs/snapshot-unionfs", "image-rs/signature-cosign-rustls", "image-rs/signature-simple", "image-rs/keywrap-native", "image-rs/encryption-ring", "image-rs/oci-distribution-rustls"]
-
-# confidential resource injection using eaa-kbc. (Deprecated)
-#
-# Note: eaa-kbc support for enclave-cc has been deprecated.
-# Check issue https://github.com/confidential-containers/enclave-cc/issues/160
-# for more information.
-eaa-kbc-rustls-tls = [ "image-rs/enclave-cc-eaakbc-rustls-tls" ]
-eaa-kbc-native-tls = [ "image-rs/enclave-cc-eaakbc-native-tls" ]
 
 # confidential resource injection using cc-kbc (Recommended)
 cc-kbc-rustls-tls = [ "image-rs/enclave-cc-cckbc-rustls-tls" ]


### PR DESCRIPTION
in old image-rs we use Attestation Agent as a lib inside to request for keys. After some refactoring, AA remains only the attestation parts. This patch updates image-rs version after that refactoring.

see https://github.com/confidential-containers/guest-components/issues/412