### PR TITLE
ci: update e2e to use organization runner

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: sgx-ecc
+          - runner: sgx
             sgx_mode: HW
             kbc: cc-kbc
           - runner: ubuntu-22.04


### PR DESCRIPTION
If this PR works, I think we can delete the repo runner of `sgx-ecc`. cc @mythi 